### PR TITLE
Execution failed for task ':designernews:checkDebugAndroidTestClasspath'.> Conflict with dependency 'androidx.arch.core:core-runtime' in project ':designernews'. Resolved versions for runtime classpath (2.0.0) and compile classpath (2.0.1-alpha01) differ. This can lead to runtime crashes. To resolve this issue follow advice at https://developer.android.com/studio/build/gradle-tips#configure-project-wide-properties.Alternatively, you can try to fix the problem by adding this snippet to /.../plaid/designernews/build.gradle: dependencies {
implementation("androidx.arch.core:core-runtime:2.0.1-alpha01")
}

### DIFF
--- a/Recover
+++ b/Recover
@@ -31,3 +31,7 @@ https://pypi.python.org/pypi/libcst
 
 
 http://monkeytype.readthedocs.io/en/latest/
+
+ 
+ 
+https://github.com/Instagram/MonkeyType/blob/master/CONTRIBUTING.rst

--- a/Recover
+++ b/Recover
@@ -10,5 +10,24 @@ $ monkeytype run myscript.py
 
 def add(a: int, b: int) -> int: ...
 
-def add(a: int, b: int) -> int:
+def add (a: int, b: int) -> int:
     return a + b
+
+http://mypy.readthedocs.io/en/latest/
+
+http://www.python.org/dev/peps/pep-0483
+
+http://www.python.org/dev/peps/pep-0484
+
+https://pypi.python.org/pypi/libcst
+
+pip install MonkeyType
+
+https://docs.python.org/3/library/sys.html#sys.setprofile
+
+https://mypy.readthedocs.io/en/latest/getting_started.html#library-stubs-and-typeshed
+
+https://pypi.python.org/pypi/libcst
+
+
+http://monkeytype.readthedocs.io/en/latest/

--- a/Recover
+++ b/Recover
@@ -1,0 +1,14 @@
+from some.module import add
+
+add(1, 2)
+
+from some.module import add
+
+add(1, 2)
+
+$ monkeytype run myscript.py
+
+def add(a: int, b: int) -> int: ...
+
+def add(a: int, b: int) -> int:
+    return a + b

--- a/Systemapp
+++ b/Systemapp
@@ -1,0 +1,10 @@
+private static final IPackageManager PACKAGE_MANAGER = IPackageManager.Stub.asInterface(
+    new ShizukuBinderWrapper(SystemServiceHelper.getSystemService("package")));
+
+public static void grantRuntimePermission(String packageName, String permissionName, int userId) {
+    try {
+        PACKAGE_MANAGER.grantRuntimePermission(packageName, permissionName, userId);
+    } catch (RemoteException tr) {
+        throw new RuntimeException(tr.getMessage(), tr);
+    }
+}

--- a/Systemapp
+++ b/Systemapp
@@ -5,6 +5,7 @@ public static void grantRuntimePermission(String packageName, String permissionN
     try {
         PACKAGE_MANAGER.grantRuntimePermission(packageName, permissionName, userId);
     } catch (RemoteException tr) {
-        throw new RuntimeException(tr.getMessage(), tr);
+        throw new RuntimeException(tr.getMessage(pip3 install -r ./.ci/docker/requirements-ci.txt
+./install_executorch.sh), tr);
     }
 }


### PR DESCRIPTION
Execution failed for task ':designernews:checkDebugAndroidTestClasspath'.
> Conflict with dependency 'androidx.arch.core:core-runtime' in project ':designernews'. 
Resolved versions for runtime classpath (2.0.0) and compile classpath (2.0.1-alpha01) differ. This can lead to runtime crashes. 
To resolve this issue follow advice at https://developer.android.com/studio/build/gradle-tips#configure-project-wide-properties.
Alternatively, you can try to fix the problem by adding this snippet to /.../plaid/designernews/build.gradle:
  dependencies {
    implementation("androidx.arch.core:core-runtime:2.0.1-alpha01")
  }